### PR TITLE
Binary data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,216 @@
+language: rust
+cache: cargo
+
+env:
+  global:
+    # This will be part of the release tarball
+    - PROJECT_NAME=wsta
+    # - MAKE_DEB=yes
+    # - DEB_MAINTAINER="Jorge Aparicio <japaricious@gmail.com>"
+    # - DEB_DESCRIPTION="Hello, world! written in Rust"
+
+# AFAICT There are a few ways to set up the build jobs. This one is not the DRYest but I feel is the
+# easiest to reason about.
+# NOTE Make *sure* you don't remove a reference (&foo) if you are going to dereference it (*foo)
+matrix:
+  include:
+    # Stable channel
+    # TODO Uncomment stable channel when cargo 0.10 is stable
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=aarch64-unknown-linux-gnu
+    #   # need Trusty because the glibc in Precise is too old and doesn't support 64-bit arm
+    #   dist: trusty
+    #   sudo: required
+    #   # Extra packages only for this job
+    #   addons:
+    #     apt:
+    #       packages: &aarch64_unknown_linux_gnu
+    #         # Transparent emulation
+    #         - qemu-user-static
+    #         - binfmt-support
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=armv7-unknown-linux-gnueabihf
+    #   # sudo is needed for binfmt_misc, which is needed for transparent user qemu emulation
+    #   sudo: required
+    #   addons:
+    #     apt:
+    #       packages: &armv7_unknown_linux_gnueabihf
+    #         # Cross compiler and cross compiled C libraries
+    #         - gcc-arm-linux-gnueabihf
+    #         - libc6-armhf-cross
+    #         - libc6-dev-armhf-cross
+    #         # Transparent emulation
+    #         - qemu-user-static
+    #         - binfmt-support
+    # - os: osx
+    #   rust: stable
+    #   env: TARGET=i686-apple-darwin
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=i686-unknown-linux-gnu
+    #   sudo: required
+    #   addons:
+    #     apt:
+    #       packages: &i686_unknown_linux_gnu
+    #         # Cross compiler and cross compiled C libraries
+    #         - gcc-multilib
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=i686-unknown-linux-musl
+    #   sudo: required
+    # - os: osx
+    #   rust: stable
+    #   env: TARGET=x86_64-apple-darwin
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=x86_64-unknown-linux-gnu
+    #   sudo: required
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=x86_64-unknown-linux-musl
+    #   sudo: required
+    # Beta channel
+    - os: linux
+      rust: beta
+      env: TARGET=aarch64-unknown-linux-gnu
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages: &aarch64_unknown_linux_gnu
+            # Transparent emulation
+            - qemu-user-static
+            - binfmt-support
+    - os: linux
+      rust: beta
+      env: TARGET=armv7-unknown-linux-gnueabihf
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          # Use the same packages the stable version uses
+          packages: &armv7_unknown_linux_gnueabihf
+            # Transparent emulation
+            - qemu-user-static
+            - binfmt-support
+    - os: osx
+      rust: beta
+      env: TARGET=i686-apple-darwin
+    - os: linux
+      rust: beta
+      env: TARGET=i686-unknown-linux-gnu
+      sudo: required
+      addons:
+        apt:
+          packages: &i686_unknown_linux_gnu
+            # Cross compiler and cross compiled C libraries
+            - gcc-multilib
+    - os: linux
+      rust: beta
+      env: TARGET=i686-unknown-linux-musl
+      sudo: required
+    - os: osx
+      rust: beta
+      env: TARGET=x86_64-apple-darwin
+    - os: linux
+      rust: beta
+      env: TARGET=x86_64-unknown-linux-gnu
+      sudo: required
+    - os: linux
+      rust: beta
+      env: TARGET=x86_64-unknown-linux-musl
+      sudo: required
+    # Nightly channel
+    - os: linux
+      rust: nightly
+      env: TARGET=aarch64-unknown-linux-gnu
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages: *aarch64_unknown_linux_gnu
+    - os: linux
+      rust: nightly
+      env: TARGET=armv7-unknown-linux-gnueabihf
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          # Use the same packages the stable version uses
+          packages: *armv7_unknown_linux_gnueabihf
+    - os: osx
+      rust: nightly
+      env: TARGET=i686-apple-darwin
+    - os: linux
+      rust: nightly
+      env: TARGET=i686-unknown-linux-gnu
+      sudo: required
+      addons:
+        apt:
+          packages: *i686_unknown_linux_gnu
+    - os: linux
+      rust: nightly
+      env: TARGET=i686-unknown-linux-musl
+      sudo: required
+    - os: osx
+      rust: nightly
+      env: TARGET=x86_64-apple-darwin
+    - os: linux
+      rust: nightly
+      env: TARGET=x86_64-unknown-linux-gnu
+      sudo: required
+    - os: linux
+      rust: nightly
+      env: TARGET=x86_64-unknown-linux-musl
+      sudo: required
+  allow_failures:
+    # Target `i686-unknown-linux-musl` is currently only available on the nightly channel
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=i686-unknown-linux-musl
+    - os: linux
+      rust: beta
+      env: TARGET=i686-unknown-linux-musl
+
+before_install:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+
+install:
+  - bash ci/install.sh
+
+script:
+  - bash ci/script.sh
+
+before_deploy:
+  - bash ci/before_deploy.sh
+
+deploy:
+  provider: releases
+  # Encrypted API key using travis cli's encrypt
+  api_key:
+    secure: "HGVJap2744AiiqYP9A4bSwKU0UmB9yfOE6i77Fj4Y7f9HMYDBsC8P63AXt0ixXo1mEsWTjVtEZPNjAt1daxURc06xT3RkUw+BldJ/XhG4O1Tei9i0aVIB6t82HLnuvi89FFRJSdWkNMeKWoTh/Q/6c6aBuCmQzb8QGyne6MGXiDLV8z9hTIefTTfyAxjFY/25aPy/isvidVvdxU1SY+IBOnYAxYRmXFQLjDIn0pEu7j2cYw8ub0CGqRLfdoXfwCs0cgVx9Ikjy8x4CoUrxnKps+RSMt/uCZPrb1lMxgR0Bzv82K9TEY7nItn0pr5IilLj6aFZ+0k79VKse77S9st/vEmdxB8CCFOjL/GRnq+6BqFgZqZJVe25lgUwvzNfuidCo0uF4qlKNAi9bX9I0w6KTDkmRlWGb8nKcX2fxBfdb4ePt3RANdK7ZOMT3Brmxn+TjgFKOktkRNDVsIDO2cKUpXOlGyygjnZC5MyvoXov8mBvq5mywpFCozTYEZIciSLfyFC7TNgciWbEzEy9IOeQ73X0OGSvMNsxH05J8r7pZTzDnunhwPTEHG4wUcnQpqOf16lv5LQn8z/wIZ8nszLP0JlE0zz6Rq8Gn/8193v0ykqlHAAqV8isbvNHad1yksgMueHReEgqz8dDpaCsG0VkPq6FIi5sTDKjkruAkH1NyA="
+  file_glob: true
+  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.*
+  # don't delete the artifacts from previous phases
+  skip_cleanup: true
+  # deploy when a new tag is pushed
+  on:
+    # channel to use to produce the release artifacts
+    # NOTE make sure you only release *once* per target
+    condition: $TRAVIS_RUST_VERSION = beta
+    tags: true
+
+branches:
+  only:
+    # Pushes and PR to the master branch
+    - master
+    - rust-everywhere
+    # IMPORTANT Ruby regex to match tags. Required, or travis won't trigger deploys when a new tag
+    # is pushed. This regex matches semantic versions like v1.2.3-rc4+2016.02.22
+    - /^\d+\.\d+\.\d+.*$/
+
+notifications:
+  email:
+    on_success: never

--- a/HomebrewFormula/wsta.rb
+++ b/HomebrewFormula/wsta.rb
@@ -2,7 +2,7 @@ class Wsta < Formula
   desc "A cli tool written in rust for interfacing with WebSocket services."
   homepage "https://github.com/esphen/wsta"
   url "https://github.com/esphen/wsta/archive/0.2.1.tar.gz"
-  sha256 "7923e9bd8310b5a72d8390324bd5150615d0e587ec793f808e12cddbb03e238f"
+  sha256 "48c2c1a73cab9955df0c2cb494d536e904dafa19a7c8ac7c6dac64ae2cb6240a"
 
   depends_on 'gpg' => :build
   depends_on 'multirust' => :build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The WebSocket Transfer Agent
 
+[![Build Status](https://travis-ci.org/esphen/wsta.svg?branch=rust-everywhere)](https://travis-ci.org/esphen/wsta)
+
 `wsta` is a cli tool written in rust for interfacing with WebSockets. `wsta` has
 the philosophy of being an easy tool to learn and thus gets out of your way to
 let you work your UNIX magic directly on the WebSocket traffic.

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,66 @@
+# `before_deploy` phase: here we package the build artifacts
+
+set -ex
+
+. $(dirname $0)/utils.sh
+
+# Generate artifacts for release
+mk_artifacts() {
+    cargo build --target $TARGET --release
+}
+
+mk_tarball() {
+    # create a "staging" directory
+    local td=$(mktempd)
+    local out_dir=$(pwd)
+
+    # NOTE All Cargo build artifacts will be under the 'target/$TARGET/{debug,release}'
+    cp target/$TARGET/release/wsta $td
+
+    pushd $td
+
+    # release tarball will look like 'rust-everywhere-v1.2.3-x86_64-unknown-linux-gnu.tar.gz'
+    tar czf $out_dir/${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz *
+
+    popd
+    rm -r $td
+}
+
+# Package your artifacts in a .deb file
+# NOTE right now you can only package binaries using the `dobin` command. Simply call
+# `dobin [file..]` to include one or more binaries in your .deb package. I'll add more commands to
+# install other things like manpages (`doman`) as the needs arise.
+# XXX This .deb packaging is minimal -- just to make your app installable via `dpkg` -- and doesn't
+# fully conform to Debian packaging guideliens (`lintian` raises a few warnings/errors)
+mk_deb() {
+    dobin target/$TARGET/release/wsta
+}
+
+main() {
+    mk_artifacts
+    mk_tarball
+
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        if [ ! -z $MAKE_DEB ]; then
+            dtd=$(mktempd)
+            mkdir -p $dtd/debian/usr/bin
+
+            mk_deb
+
+            mkdir -p $dtd/debian/DEBIAN
+            cat >$dtd/debian/DEBIAN/control <<EOF
+Package: $PROJECT_NAME
+Version: ${TRAVIS_TAG#v}
+Architecture: $(architecture $TARGET)
+Maintainer: $DEB_MAINTAINER
+Description: $DEB_DESCRIPTION
+EOF
+
+            fakeroot dpkg-deb --build $dtd/debian
+            mv $dtd/debian.deb $PROJECT_NAME-$TRAVIS_TAG-$TARGET.deb
+            rm -r $dtd
+        fi
+    fi
+}
+
+main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,81 @@
+# `install` phase: install stuff needed for the `script` phase
+
+set -ex
+
+. $(dirname $0)/utils.sh
+
+install_c_toolchain() {
+    case $TARGET in
+        aarch64-unknown-linux-gnu)
+            sudo apt-get install -y --no-install-recommends \
+                 gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+            ;;
+        armv7-unknown-linux-gnueabihf)
+            sudo apt-get install -y --no-install-recommends \
+                gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross
+            ;;
+        *)
+            # For other targets, this is handled by addons.apt.packages in .travis.yml
+            ;;
+    esac
+}
+
+install_rustup() {
+    # uninstall the rust toolchain installed by travis, we are going to use rustup
+    sh ~/rust/lib/rustlib/uninstall.sh
+
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=$TRAVIS_RUST_VERSION
+
+    rustc -V
+    cargo -V
+}
+
+install_standard_crates() {
+    if [ $(host) != "$TARGET" ]; then
+        rustup target add $TARGET
+    fi
+}
+
+configure_cargo() {
+    local prefix=$(gcc_prefix)
+
+    if [ ! -z $prefix ]; then
+        # information about the cross compiler
+        ${prefix}gcc -v
+
+        # tell cargo which linker to use for cross compilation
+        mkdir -p .cargo
+        cat >>.cargo/config <<EOF
+[target.$TARGET]
+linker = "${prefix}gcc"
+EOF
+    fi
+}
+
+main() {
+    install_c_toolchain
+    install_rustup
+    install_standard_crates
+    configure_cargo
+
+    case "$TRAVIS_OS_NAME" in
+        linux)
+            # libssl-dev is in backports for ARM
+            if [[ "$(architecture $TARGET)" == arm* ]]; then
+
+              sudo sh -c 'echo "deb [arch=arm64,armhf] http://ports.ubuntu.com trusty main universe" >> /etc/apt/sources.list'
+              sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1397BC53640DB551
+            fi
+
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends \
+              "libssl-dev:$(architecture $TARGET)" gcc-multilib
+            ;;
+        osx)
+            brew update
+            brew install openssl
+            ;;
+    esac
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,54 @@
+# `script` phase: you usually build, test and generate docs in this phase
+
+set -ex
+
+. $(dirname $0)/utils.sh
+
+# NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
+# This has been fixed in the nightly channel but it would take a while to reach the other channels
+disable_cross_doctests() {
+    if [ $(host) != "$TARGET" ] && [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+        if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+            brew install gnu-sed --default-names
+        fi
+
+        find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
+    fi
+}
+
+# TODO modify this function as you see fit
+# PROTIP Always pass `--target $TARGET` to cargo commands, this makes cargo output build artifacts
+# to target/$TARGET/{debug,release} which can reduce the number of needed conditionals in the
+# `before_deploy`/packaging phase
+run_test_suite() {
+    case $TARGET in
+        # configure emulation for transparent execution of foreign binaries
+        aarch64-unknown-linux-gnu)
+            export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
+            ;;
+        arm*-unknown-linux-gnueabihf)
+            export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf
+            ;;
+        *)
+            ;;
+    esac
+
+    if [ ! -z "$QEMU_LD_PREFIX" ]; then
+        # Run tests on a single thread when using QEMU user emulation
+        export RUST_TEST_THREADS=1
+    fi
+
+    cargo build --target $TARGET --verbose
+    cargo run --target $TARGET -- --help
+    cargo test --target $TARGET
+
+    # sanity check the file type
+    file target/$TARGET/debug/wsta
+}
+
+main() {
+    disable_cross_doctests
+    run_test_suite
+}
+
+main

--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -1,0 +1,59 @@
+mktempd() {
+    echo $(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+}
+
+host() {
+    case "$TRAVIS_OS_NAME" in
+        linux)
+            echo x86_64-unknown-linux-gnu
+            ;;
+        osx)
+            echo x86_64-apple-darwin
+            ;;
+    esac
+}
+
+gcc_prefix() {
+    case "$TARGET" in
+        aarch64-unknown-linux-gnu)
+            echo aarch64-linux-gnu-
+            ;;
+        arm*-gnueabihf)
+            echo arm-linux-gnueabihf-
+            ;;
+        *)
+            return
+            ;;
+    esac
+}
+
+dobin() {
+    [ -z $MAKE_DEB ] && die 'dobin: $MAKE_DEB not set'
+    [ $# -lt 1 ] && die "dobin: at least one argument needed"
+
+    local f prefix=$(gcc_prefix)
+    for f in "$@"; do
+        install -m0755 $f $dtd/debian/usr/bin/
+        ${prefix}strip -s $dtd/debian/usr/bin/$(basename $f)
+    done
+}
+
+architecture() {
+    case $1 in
+        x86_64-unknown-linux-gnu|x86_64-unknown-linux-musl)
+            echo amd64
+            ;;
+        i686-unknown-linux-gnu|i686-unknown-linux-musl)
+            echo i386
+            ;;
+        arm*-unknown-linux-gnueabihf)
+            echo armhf
+            ;;
+        aarch*-unknown-linux-gnu)
+            echo arm64
+            ;;
+        *)
+            die "architecture: unexpected target $TARGET"
+            ;;
+    esac
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,0 @@
-pub const DEFAULT_BINARY_FRAME_SIZE: &'static str = "2048";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,1 @@
+pub const DEFAULT_BINARY_FRAME_SIZE: &'static str = "2048";

--- a/src/frame_data.rs
+++ b/src/frame_data.rs
@@ -1,0 +1,20 @@
+/// Holds a frame of either utf8 encoded or binary data.
+#[derive(Debug)]
+pub struct FrameData {
+    pub utf8: Option<String>,
+    pub binary: Option<Vec<u8>>
+}
+
+impl FrameData {
+    pub fn from_utf8(utf8: String) -> FrameData {
+        FrameData { utf8: Some(utf8), binary: None }
+    }
+
+    pub fn from_binary_buffer(binary: Vec<u8>) -> FrameData {
+        FrameData { utf8: None, binary: Some(binary) }
+    }
+
+    pub fn is_utf8(&self) -> bool {
+        self.utf8.is_some()
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,7 +11,6 @@ use hyper::header::{Headers, SetCookie, Cookie};
 use hyper::status::StatusCode;
 use hyper::client::RedirectPolicy;
 
-use log;
 use options::Options;
 
 pub fn fetch_session_cookie(options: &Options) -> Option<Cookie> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -75,14 +75,14 @@ pub fn fetch_session_cookie(options: &Options) -> Option<Cookie> {
 
 pub fn print_headers(title: &str, headers: &Headers,
                      status: Option<StatusCode>) {
-    println!("{}", title);
-    println!("---");
+    stderr!("{}", title);
+    stderr!("---");
 
     if status.is_some() {
-        println!("{}", status.unwrap());
+        stderr!("{}", status.unwrap());
     }
 
-    println!("{}\n", headers);
+    stderr!("{}\n", headers);
 }
 
 /// Finds the cookie with name matching .*session.* and returns it

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,30 +1,30 @@
 static mut log_level: u8 = 0;
 
+macro_rules! stderr {
+    ( $( $msg:tt )* ) => {{
+        writeln!(io::stderr(), $($msg)*).unwrap();
+    }}
+}
+
 macro_rules! log {
     // No format string
     ($loudness:expr, $msg:expr ) => {{
         let log_level = $crate::log::get_log_level();
 
         if log_level >= $loudness  {
-            println!("VERB {}: {}", $loudness, $msg);
+            stderr!("VERB {}: {}", $loudness, $msg);
         }
     }};
     // Format string and args
     ($loudness:expr, $( $msg:tt )* ) => {{
 
-        let log_level = log::get_log_level();
+        let log_level = $crate::log::get_log_level();
 
         if log_level >= $loudness  {
             let pretty_msg = format!($($msg)*);
-            println!("VERB {}: {}", $loudness, pretty_msg);
+            stderr!("VERB {}: {}", $loudness, pretty_msg);
         }
     }};
-}
-
-macro_rules! stderr {
-    ( $( $msg:tt )* ) => {{
-        writeln!(io::stderr(), $($msg)*).unwrap();
-    }}
 }
 
 /// Sets the log level of the application. See `Options::verbosity` for

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ extern crate cookie;
 // Needs to be imported first because of log! macro
 #[macro_use]
 mod log;
-mod constants;
 mod frame_data;
 mod program;
 mod http;
@@ -98,6 +97,9 @@ fn main() {
                                     env!("CARGO_PKG_VERSION"))
                             ),
                       "print version number and exit");
+
+        ap.refer(&mut options.binary_frame_size)
+            .envvar("WSTA_BINARY_FRAME_SIZE");
 
         ap.refer(&mut options.messages)
             .add_argument("messages", Collect,

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ extern crate cookie;
 // Needs to be imported first because of log! macro
 #[macro_use]
 mod log;
+mod constants;
 mod frame_data;
 mod program;
 mod http;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,9 +74,8 @@ fn main() {
             .add_option(&["-l", "--login"], Store,
                         "URL to authenticate with before connecting to WS");
 
-        ap.refer(&mut options.binary_frame_size)
-            .metavar("KB")
-            .add_option(&["-b", "--binary-frame-size"], StoreOption,
+        ap.refer(&mut options.binary_mode)
+            .add_option(&["-b", "--binary"], StoreTrue,
                         "specify size of binary frames. Default is 5KB");
 
         ap.refer(&mut options.follow_redirect)

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ extern crate cookie;
 // Needs to be imported first because of log! macro
 #[macro_use]
 mod log;
+mod frame_data;
 mod program;
 mod http;
 mod ws;
@@ -70,6 +71,11 @@ fn main() {
         ap.refer(&mut options.login_url)
             .add_option(&["-l", "--login"], Store,
                         "URL to authenticate with before connecting to WS");
+
+        ap.refer(&mut options.binary_frame_size)
+            .metavar("KB")
+            .add_option(&["-b", "--binary-frame-size"], StoreOption,
+                        "specify size of binary frames. Default is 5KB");
 
         ap.refer(&mut options.follow_redirect)
             .add_option(&["--follow-redirect"], StoreTrue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@
 //! Connect to a WebSocket server
 //!
 //! ```bash
-//! wsta -u wss://echo.websocket.org
+//! wsta wss://echo.websocket.org
 //! ```
 //!
 //! # Exit codes
@@ -33,6 +33,8 @@ mod ws;
 mod options;
 
 use argparse::*;
+use std::io;
+use std::io::Write;
 
 use options::Options;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,11 +5,12 @@ use std::vec::Vec;
 pub struct Options {
 
     /// The verbosity level of the application. Should be a number
-    /// between 0 and 3.
+    /// between 0 and 4.
     /// * 0:   NO LOGGING
     /// * 1:   ERROR LOGGING
     /// * 2:   DEBUG LOGGING
-    /// * >=3: TRACE LOGGING
+    /// * 3:   TRACE LOGGING
+    /// * >=4: BINARY LOGGING
     pub verbosity: u8,
 
     /// The WebSocket URL to connect to.
@@ -38,7 +39,11 @@ pub struct Options {
 
     /// If provided, will specify an interval for wsta to send a ping
     /// frame to the server.
-    pub ping_interval: Option<u64>
+    pub ping_interval: Option<u64>,
+
+    /// If provided, will specify an interval for wsta to send a ping
+    /// frame to the server.
+    pub binary_frame_size: Option<usize>,
 }
 
 impl Options {
@@ -52,7 +57,8 @@ impl Options {
             print_headers: false,
             headers: Vec::new(),
             messages: Vec::new(),
-            ping_interval: None
+            ping_interval: None,
+            binary_frame_size: None
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -44,6 +44,10 @@ pub struct Options {
     /// If provided, will turn the program into a binary mode, reading 255 bytes
     /// at a time and sending frames when the buffer is filled
     pub binary_mode: bool,
+
+    /// Specifies the amount of bytes per frame to send when
+    /// sending binary data.
+    pub binary_frame_size: String
 }
 
 impl Options {
@@ -58,7 +62,8 @@ impl Options {
             headers: Vec::new(),
             messages: Vec::new(),
             ping_interval: None,
-            binary_mode: false
+            binary_mode: false,
+            binary_frame_size: String::from("256")
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -41,9 +41,9 @@ pub struct Options {
     /// frame to the server.
     pub ping_interval: Option<u64>,
 
-    /// If provided, will specify an interval for wsta to send a ping
-    /// frame to the server.
-    pub binary_frame_size: Option<usize>,
+    /// If provided, will turn the program into a binary mode, reading 255 bytes
+    /// at a time and sending frames when the buffer is filled
+    pub binary_mode: bool,
 }
 
 impl Options {
@@ -58,7 +58,7 @@ impl Options {
             headers: Vec::new(),
             messages: Vec::new(),
             ping_interval: None,
-            binary_frame_size: None
+            binary_mode: false
         }
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,4 +1,3 @@
-use std;
 use std::io;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
@@ -131,7 +130,6 @@ pub fn run_wsta(options: &mut Options) {
     // Share mutable data between writer thread and main thread
     // using a lockable Mutex.
     // Mutex will block threads waiting for the lock to become available
-    std::thread::sleep(Duration::from_secs(2));
     let stdin_buffer = ws::spawn_stdin_reader::<Arc<Mutex<Vec<FrameData>>>>
         (options.echo, options.binary_mode);
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -11,7 +11,6 @@ use websocket::client::Receiver as ReceiverObj;
 use websocket::client::request::{Request, Url};
 use websocket::stream::WebSocketStream;
 
-use log;
 use ws;
 use options::Options;
 use frame_data::FrameData;

--- a/src/program.rs
+++ b/src/program.rs
@@ -131,7 +131,7 @@ pub fn run_wsta(options: &mut Options) {
     // using a lockable Mutex.
     // Mutex will block threads waiting for the lock to become available
     let stdin_buffer = ws::spawn_stdin_reader::<Arc<Mutex<Vec<FrameData>>>>
-        (options.echo, options.binary_mode);
+        (options.echo, options.binary_mode, options.binary_frame_size.clone());
 
     // Variables for checking against a ping interval
     let ping_interval = options.ping_interval.map(|i| Duration::from_secs(i));

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,3 +1,4 @@
+use std;
 use std::io;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
@@ -130,8 +131,9 @@ pub fn run_wsta(options: &mut Options) {
     // Share mutable data between writer thread and main thread
     // using a lockable Mutex.
     // Mutex will block threads waiting for the lock to become available
+    std::thread::sleep(Duration::from_secs(2));
     let stdin_buffer = ws::spawn_stdin_reader::<Arc<Mutex<Vec<FrameData>>>>
-        (options.echo, options.binary_frame_size);
+        (options.echo, options.binary_mode);
 
     // Variables for checking against a ping interval
     let ping_interval = options.ping_interval.map(|i| Duration::from_secs(i));

--- a/wsta.1
+++ b/wsta.1
@@ -1,5 +1,5 @@
 ." vim: set spell so=8:
-.TH wsta 1 "17 May 2016" "0.2.1"
+.TH wsta 1 "03 Jun 2016" "0.2.1"
 .SH NAME
 wsta \- The WebSocket Transfer Agent
 .SH SYNOPSIS
@@ -99,6 +99,21 @@ placed into the WebSocket request. Using this method,
 can connect to WebSockets behind a login.
 
 .TP
+.B -b, --binary
+Setting this flag will set
+.B wsta
+into a binary mode. In this mode,
+.B wsta
+will read binary data from stdin and send it in 256B frames to the sever. If
+larger or smaller frames are required, the
+.B WSTA_BINARY_FRAME_SIZE
+environment variable can be provided to override this.
+.B WSTA_BINARY_FRAME_SIZE
+is specified as the max number of Bytes in each frame.
+Binary data sent from the server is automatically recognized and printed, there
+is no need to specify this flag when binary output is expected.
+
+.TP
 .B --follow-redirect
 Related to the
 .B --login
@@ -130,6 +145,21 @@ then exits.
 .TP
 .B -h, --help
 Shows a helpful message containing all supported input parameters, then exits.
+
+.SH ENVIRONMENT VARIABLES
+
+.TP
+.B WSTA_BINARY_FRAME_SIZE
+If used with the
+.B --binary
+flag,
+.B WSTA_BINARY_FRAME_SIZE
+will specify the maximum size of each binary frame. This is a number in Bytes.
+If
+.B --binary
+is used, but this variable is not set, then a default of 256 Bytes will be used.
+This may be small for persistent streaming data, and a "overrun!!!" message may
+show, in which case simply increase the fame size using this variable.
 
 .SH EXAMPLES
 

--- a/wsta.md
+++ b/wsta.md
@@ -81,19 +81,30 @@
               connect to WebSockets behind a login.
 
 
+       -b, --binary
+              Setting this flag will set wsta into  a  binary  mode.  In  this
+              mode,  wsta will read binary data from stdin and send it in 256B
+              frames to the sever. If larger or smaller frames  are  required,
+              the  WSTA_BINARY_FRAME_SIZE environment variable can be provided
+              to override this.  WSTA_BINARY_FRAME_SIZE is  specified  as  the
+              max  number  of  Bytes in each frame.  Binary data sent from the
+              server is automatically recognized and printed, there is no need
+              to specify this flag when binary output is expected.
+
+
        --follow-redirect
-              Related to the --login option above, this  request  will  change
-              the  default  behavior.  By default --login will not follow HTTP
-              redirects. But if provided  with  the  --follow-redirect  option
+              Related  to  the  --login option above, this request will change
+              the default behavior. By default --login will  not  follow  HTTP
+              redirects.  But  if  provided  with the --follow-redirect option
               wsta will honour any redirects the server requests.
 
 
        -v, --verbose
               Make wsta more verbose. This option will print varying levels of
-              output to stdout. It can be provided up to three times in  order
-              to  log  more  verbose  output. The first level will mostly just
+              output  to stdout. It can be provided up to three times in order
+              to log more verbose output. The first  level  will  mostly  just
               tell you which step wsta is currently executing and provide more
-              detailed  error reports. The two other options are for debugging
+              detailed error reports. The two other options are for  debugging
               purposes.
 
 
@@ -102,8 +113,18 @@
 
 
        -h, --help
-              Shows a helpful message containing all supported  input  parame-
+              Shows  a  helpful message containing all supported input parame-
               ters, then exits.
+
+
+## ENVIRONMENT VARIABLES
+       WSTA_BINARY_FRAME_SIZE
+              If used with  the  --binary  flag,  WSTA_BINARY_FRAME_SIZE  will
+              specify  the maximum size of each binary frame. This is a number
+              in Bytes.  If --binary is used, but this variable  is  not  set,
+              then a default of 256 Bytes will be used.  This may be small for
+              persistent streaming data, and a "overrun!!!" message may  show,
+              in which case simply increase the fame size using this variable.
 
 
 ## EXAMPLES
@@ -133,4 +154,4 @@
 
 
 
-0.2.1                             17 May 2016                          wsta(1)
+0.2.1                             03 Jun 2016                          wsta(1)


### PR DESCRIPTION
Add support for binary frames, both from stdin to the server, and from the server to stdout

Adds a new argument, `-b, --binary`. This turns `wsta` into sending binary mode. Everything from stdin will then be parsed as binary, and sent in 256B frames. You can increase or decrease this frame size using the environment variable `WSTA_BINARY_FRAME_SIZE`.

See #5 

Also closes #4 

The merge diff is a bit messy because I rebased the `rust-everywhere` branch, but this branch is not aware of it.
